### PR TITLE
Added missing sched_time column to qrtz_fired_triggers in 1.8.x to 2.2.x migration guide

### DIFF
--- a/documentation/quartz-2.2.x/migration-guide.md
+++ b/documentation/quartz-2.2.x/migration-guide.md
@@ -345,6 +345,10 @@ alter table qrtz_scheduler_state add column sched_name varchar(120) not null DEF
 alter table qrtz_simple_triggers add column sched_name varchar(120) not null DEFAULT 'TestScheduler';
 alter table qrtz_triggers add column sched_name varchar(120) not null DEFAULT 'TestScheduler';
 -
+- add new 'sched_time' column to qrtz_fired_triggers
+-
+alter table qrtz_fired_triggers add column sched_time BIGINT(13) NOT NULL;
+-
 - drop all primary and foreign key constraints, so that we can define new ones
 -
 alter table qrtz_triggers drop constraint qrtz_triggers_job_name_fkey;


### PR DESCRIPTION
Statement to add sched_time column to qrtz_fired_triggers is missing in the 1.8.x to 2.2.x migration guide. 
Going through the scripts looks like this column was introduced in 2.2.0 and not there in 2.1.7 script. See below for mentioned scripts.

http://svn.terracotta.org/svn/quartz/tags/quartz-2.1.7/docs/dbTables/tables_mysql_innodb.sql
http://svn.terracotta.org/svn/quartz/tags/quartz-2.2.0/distribution/src/main/assembly/root/docs/dbTables/tables_mysql_innodb.sql

added a single statement to add the missing column