### PR TITLE
Escape asterisk

### DIFF
--- a/documentation/quartz-1.x/tutorials/crontrigger.md
+++ b/documentation/quartz-1.x/tutorials/crontrigger.md
@@ -110,7 +110,7 @@ or more complex, like this: <tt>0/5 14,18,3-39,52 * ? JAN,MAR,SEP MON-FRI 2002-2
 
 + <tt>**/**</tt> &#45; used to specify increments. For example, "0/15" in the seconds field means *"the
     seconds 0, 15, 30, and 45"*. And "5/15" in the seconds field means *"the seconds 5, 20, 35, and 50"*. You can
-    also specify '/' after the '**' character - in this case '**' is equivalent to having '0' before the '/'. '1/3'
+    also specify '/' after the '\*' character - in this case '\*' is equivalent to having '0' before the '/'. '1/3'
     in the day-of-month field means *"fire every 3 days starting on the first day of the month"*.
 
 


### PR DESCRIPTION
The documentation without escaped * confuses a bit, so let's fix it.

<img width="889" alt="screen shot 2017-02-15 at 6 36 16 pm" src="https://cloud.githubusercontent.com/assets/4408920/22981541/b64b9bba-f3ad-11e6-86f6-0d45e482fe67.png">
