### PR TITLE
Issue #20 and Typo in Best Practices Guide

### DIFF
--- a/documentation/best-practices.md
+++ b/documentation/best-practices.md
@@ -140,7 +140,7 @@ job's "work" will be executed twice.
 This means the job should be coded in such a way that its work is idempotent.
 
 
-## Listeners (TriggerListener, JobListener, SchedulerListener
+## Listeners (TriggerListener, JobListener, SchedulerListener)
 
 
 ### Keep Code In Listeners Concise And Efficient

--- a/documentation/quartz-2.1.x/tutorials/tutorial-lesson-06.md
+++ b/documentation/quartz-2.1.x/tutorials/tutorial-lesson-06.md
@@ -122,7 +122,7 @@ CronTrigger instances are built using TriggerBuilder (for the trigger's main pro
 <pre class="prettyprint highlight"><code class="language-java" data-lang="java">
 import static org.quartz.TriggerBuilder.*;
 import static org.quartz.CronScheduleBuilder.*;
-import static org.quartz.DateBuilder.*:
+import static org.quartz.DateBuilder.*;
 </code></pre>
 
 

--- a/documentation/quartz-2.2.x/tutorials/tutorial-lesson-06.md
+++ b/documentation/quartz-2.2.x/tutorials/tutorial-lesson-06.md
@@ -122,7 +122,7 @@ CronTrigger instances are built using TriggerBuilder (for the trigger's main pro
 <pre class="prettyprint highlight"><code class="language-java" data-lang="java">
 import static org.quartz.TriggerBuilder.*;
 import static org.quartz.CronScheduleBuilder.*;
-import static org.quartz.DateBuilder.*:
+import static org.quartz.DateBuilder.*;
 </code></pre>
 
 

--- a/documentation/quartz-2.x/tutorials/tutorial-lesson-06.md
+++ b/documentation/quartz-2.x/tutorials/tutorial-lesson-06.md
@@ -124,7 +124,7 @@ CronTrigger instances are built using TriggerBuilder (for the trigger's main pro
 <pre class="prettyprint highlight"><code class="language-java" data-lang="java">
 import static org.quartz.TriggerBuilder.*;
 import static org.quartz.CronScheduleBuilder.*;
-import static org.quartz.DateBuilder.*:
+import static org.quartz.DateBuilder.*;
 </code></pre>
 
 


### PR DESCRIPTION
Fixed Typos: 
- Replaced  ':' with ';' in Tutorials, where required (issue #20 )
- Closed Brackets in Best Practices - Title