### PR TITLE
Fix quartz-1.x links

### DIFF
--- a/documentation/quartz-1.8.6/configuration/ConfigJDBCJobStoreClustering.md
+++ b/documentation/quartz-1.8.6/configuration/ConfigJDBCJobStoreClustering.md
@@ -13,7 +13,7 @@ Quartz's clustering features bring both high availability and scalability to you
 
 
 
-<img src="/images/documentation/1.x/quartz_cluster.png" align="absmiddle" border="0" />
+<img src="quartz_cluster.png" align="absmiddle" border="0" />
 
 
 Clustering currently only works with the JDBC-Jobstore (JobStoreTX or JobStoreCMT), and essentially works by having each node of the cluster share the same database.  

--- a/documentation/quartz-1.8.6/cookbook/index.md
+++ b/documentation/quartz-1.8.6/cookbook/index.md
@@ -20,7 +20,7 @@ Choose from the following menu of How-Tos:
 * <a href="/documentation/quartz-1.x/cookbook/ListJobs" title="ListJobs">Listing Jobs in the Scheduler</a>
 * <a href="/documentation/quartz-1.x/cookbook/ListTriggers" title="ListTriggers">Listing Triggers in the Scheduler</a>
 * <a href="/documentation/quartz-1.x/cookbook/JobTriggers" title="JobTriggers">Finding Triggers of a Job</a>
-<!--
+<!---
 * Using a Global JobListener
 * Using a Global TriggerListener
 * Using a Job-Specific JobListener

--- a/documentation/quartz-1.8.6/cookbook/index.md
+++ b/documentation/quartz-1.8.6/cookbook/index.md
@@ -4,34 +4,34 @@ The Quartz cookbook is a collection of succinct code examples of doing specific 
 
 Choose from the following menu of How-Tos:
 
-* <a href="/documentation/quartz-1.x/cookbook/CreateScheduler" title="CreateScheduler">Instantiating a Scheduler</a>
-* <a href="/documentation/quartz-1.x/cookbook/SchedulerStandby" title="SchedulerStandby">Placing a Scheduler in Stand-by Mode</a>
-* <a href="/documentation/quartz-1.x/cookbook/ShutdownScheduler" title="ShutdownScheduler">Shutting Down a Scheduler</a>
-* <a href="/documentation/quartz-1.x/cookbook/ServletInitScheduler" title="ServletInitScheduler">Initializing a Scheduler Within a Servlet Container</a>
-* <a href="/documentation/quartz-1.x/cookbook/MultipleSchedulers" title="ServletInitScheduler">Utilizing Multiple (Non-Clustered) Scheduler Instances</a>
-* <a href="/documentation/quartz-1.x/cookbook/DefineJobWithData" title="DefineJobWithData">Defining a Job</a>
-* <a href="/documentation/quartz-1.x/cookbook/ScheduleJob" title="ScheduleJob">Defining and Scheduling a Job</a>
-* <a href="/documentation/quartz-1.x/cookbook/UnscheduleJob" title="UnscheduleJob">Unscheduling a Job</a>
-* <a href="/documentation/quartz-1.x/cookbook/StoreJob" title="StoreJob">Storing a Job For Later Scheduling</a>
-* <a href="/documentation/quartz-1.x/cookbook/ScheduleStoredJob" title="ScheduleStoreJob">Scheduling an already stored Job</a>
-* <a href="/documentation/quartz-1.x/cookbook/UpdateJob" title="UpdateJob">Updating an existing Job</a>
-* <a href="/documentation/quartz-1.x/cookbook/UpdateTrigger" title="UpdateTrigger">Updating an existing Trigger</a>
-* <a href="/documentation/quartz-1.x/cookbook/JobInitPlugin" title="JobInitPlugin">Initializing a Scheduler With Job And Triggers Defined in an XML file</a>
-* <a href="/documentation/quartz-1.x/cookbook/ListJobs" title="ListJobs">Listing Jobs in the Scheduler</a>
-* <a href="/documentation/quartz-1.x/cookbook/ListTriggers" title="ListTriggers">Listing Triggers in the Scheduler</a>
-* <a href="/documentation/quartz-1.x/cookbook/JobTriggers" title="JobTriggers">Finding Triggers of a Job</a>
+* <a href="/documentation/quartz-1.8.6/cookbook/CreateScheduler" title="CreateScheduler">Instantiating a Scheduler</a>
+* <a href="/documentation/quartz-1.8.6/cookbook/SchedulerStandby" title="SchedulerStandby">Placing a Scheduler in Stand-by Mode</a>
+* <a href="/documentation/quartz-1.8.6/cookbook/ShutdownScheduler" title="ShutdownScheduler">Shutting Down a Scheduler</a>
+* <a href="/documentation/quartz-1.8.6/cookbook/ServletInitScheduler" title="ServletInitScheduler">Initializing a Scheduler Within a Servlet Container</a>
+* <a href="/documentation/quartz-1.8.6/cookbook/MultipleSchedulers" title="ServletInitScheduler">Utilizing Multiple (Non-Clustered) Scheduler Instances</a>
+* <a href="/documentation/quartz-1.8.6/cookbook/DefineJobWithData" title="DefineJobWithData">Defining a Job</a>
+* <a href="/documentation/quartz-1.8.6/cookbook/ScheduleJob" title="ScheduleJob">Defining and Scheduling a Job</a>
+* <a href="/documentation/quartz-1.8.6/cookbook/UnscheduleJob" title="UnscheduleJob">Unscheduling a Job</a>
+* <a href="/documentation/quartz-1.8.6/cookbook/StoreJob" title="StoreJob">Storing a Job For Later Scheduling</a>
+* <a href="/documentation/quartz-1.8.6/cookbook/ScheduleStoredJob" title="ScheduleStoreJob">Scheduling an already stored Job</a>
+* <a href="/documentation/quartz-1.8.6/cookbook/UpdateJob" title="UpdateJob">Updating an existing Job</a>
+* <a href="/documentation/quartz-1.8.6/cookbook/UpdateTrigger" title="UpdateTrigger">Updating an existing Trigger</a>
+* <a href="/documentation/quartz-1.8.6/cookbook/JobInitPlugin" title="JobInitPlugin">Initializing a Scheduler With Job And Triggers Defined in an XML file</a>
+* <a href="/documentation/quartz-1.8.6/cookbook/ListJobs" title="ListJobs">Listing Jobs in the Scheduler</a>
+* <a href="/documentation/quartz-1.8.6/cookbook/ListTriggers" title="ListTriggers">Listing Triggers in the Scheduler</a>
+* <a href="/documentation/quartz-1.8.6/cookbook/JobTriggers" title="JobTriggers">Finding Triggers of a Job</a>
 <!---
 * Using a Global JobListener
 * Using a Global TriggerListener
 * Using a Job-Specific JobListener
 * Using a Trigger-Specific TriggerListener
 -->
-* <a href="/documentation/quartz-1.x/cookbook/TenSecTrigger" title="TenSecTrigger">Trigger That Fires Every 10 Seconds</a>
-* <a href="/documentation/quartz-1.x/cookbook/NintyMinTrigger" title="NintyMinTrigger">Trigger That Fires Every 90 Minutes</a>
-* <a href="/documentation/quartz-1.x/cookbook/DailyTrigger" title="DailyTrigger">Trigger That Fires Every Day</a>
-* <a href="/documentation/quartz-1.x/cookbook/BiDailyTrigger" title="BiDailyTrigger">Trigger That Fires Every 2 Days</a>
-* <a href="/documentation/quartz-1.x/cookbook/WeeklyTrigger" title="WeeklyTrigger">Trigger That Fires Every Week</a>
-* <a href="/documentation/quartz-1.x/cookbook/BiWeeklyTrigger" title="BiWeeklyTrigger">Trigger That Fires Every 2 Weeks</a>
-* <a href="/documentation/quartz-1.x/cookbook/MonthlyTrigger" title="MonthlyTrigger">Trigger That Fires Every Month</a>
-* <a href="/documentation/quartz-1.x/cookbook/FifthWorkingDayTrigger" title="FifthWorkingDayTrigger">Trigger That Fires on the Fifth "Working Day" of Every Month</a
-* <a href="/documentation/quartz-1.x/cookbook/DailyCalendarTrigger" title="DailyCalendarTrigger">Trigger That Fires Every 5 Minutes Between 8:15 AM and 5:30 PM (every day)</a>
+* <a href="/documentation/quartz-1.8.6/cookbook/TenSecTrigger" title="TenSecTrigger">Trigger That Fires Every 10 Seconds</a>
+* <a href="/documentation/quartz-1.8.6/cookbook/NintyMinTrigger" title="NintyMinTrigger">Trigger That Fires Every 90 Minutes</a>
+* <a href="/documentation/quartz-1.8.6/cookbook/DailyTrigger" title="DailyTrigger">Trigger That Fires Every Day</a>
+* <a href="/documentation/quartz-1.8.6/cookbook/BiDailyTrigger" title="BiDailyTrigger">Trigger That Fires Every 2 Days</a>
+* <a href="/documentation/quartz-1.8.6/cookbook/WeeklyTrigger" title="WeeklyTrigger">Trigger That Fires Every Week</a>
+* <a href="/documentation/quartz-1.8.6/cookbook/BiWeeklyTrigger" title="BiWeeklyTrigger">Trigger That Fires Every 2 Weeks</a>
+* <a href="/documentation/quartz-1.8.6/cookbook/MonthlyTrigger" title="MonthlyTrigger">Trigger That Fires Every Month</a>
+* <a href="/documentation/quartz-1.8.6/cookbook/FifthWorkingDayTrigger" title="FifthWorkingDayTrigger">Trigger That Fires on the Fifth "Working Day" of Every Month</a
+* <a href="/documentation/quartz-1.8.6/cookbook/DailyCalendarTrigger" title="DailyCalendarTrigger">Trigger That Fires Every 5 Minutes Between 8:15 AM and 5:30 PM (every day)</a>

--- a/documentation/quartz-1.8.6/examples/index.md
+++ b/documentation/quartz-1.8.6/examples/index.md
@@ -27,7 +27,7 @@ The source code for the examples are located in package **org.quartz.examples**.
 </thead>
 <tbody>
 <tr>
-<td width="75"> <a href="/documentation/quartz-1.x/examples/Example1" title="Example1">Example 1</a> </td>
+<td width="75"> <a href="/documentation/quartz-1.8.6/examples/Example1" title="Example1">Example 1</a> </td>
 <td> First Quartz Program </td>
 
 <td> Think of this as a "Hello World" for Quartz </td>
@@ -38,24 +38,24 @@ The source code for the examples are located in package **org.quartz.examples**.
 <td> Shows a dozen different ways of using Simple Triggers to schedule your jobs </td>
 </tr>
 <tr>
-<td> <a href="/documentation/quartz-1.x/examples/Example3" title="Example3">Example 3</a> </td>
+<td> <a href="/documentation/quartz-1.8.6/examples/Example3" title="Example3">Example 3</a> </td>
 
 <td> Cron Triggers </td>
 <td> Shows how Cron Triggers can be used to schedule your job </td>
 </tr>
 <tr>
-<td> <a href="/documentation/quartz-1.x/examples/Example4" title="Example4">Example 4</a> </td>
+<td> <a href="/documentation/quartz-1.8.6/examples/Example4" title="Example4">Example 4</a> </td>
 <td> Job State and Parameters </td>
 <td> Demonstrates how parameters can be passed into jobs and how jobs maintain state </td>
 
 </tr>
 <tr>
-<td> <a href="/documentation/quartz-1.x/examples/Example5" title="Example5">Example 5</a> </td>
+<td> <a href="/documentation/quartz-1.8.6/examples/Example5" title="Example5">Example 5</a> </td>
 <td> Handling Job Misfires </td>
 <td> Sometimes job will not execute when they are supposed to.  See how to handle these Misfires </td>
 </tr>
 <tr>
-<td> <a href="/documentation/quartz-1.x/examples/Example6" title="Example6">Example 6</a> </td>
+<td> <a href="/documentation/quartz-1.8.6/examples/Example6" title="Example6">Example 6</a> </td>
 
 <td> Dealing with Job Exceptions </td>
 <td> No job is perfect.  See how you can let the scheduler know how to deal with exceptions that are thrown by your job </td>
@@ -100,7 +100,7 @@ The source code for the examples are located in package **org.quartz.examples**.
 <td> Demonstrates how Quartz can be used in a clustered environment and how Quartz can use the database to persist scheduling information </td>
 </tr>
 <tr>
-<td> <a href="/documentation/quartz-1.x/examples/Example14" title="Example14">Example 14</a> </td>
+<td> <a href="/documentation/quartz-1.8.6/examples/Example14" title="Example14">Example 14</a> </td>
 
 <td> Trigger Priorities </td>
 <td> Demonstrates how Trigger priorities can be used to manage firing order for Triggers with the same fire time </td>

--- a/documentation/quartz-1.8.6/examples/index.md
+++ b/documentation/quartz-1.8.6/examples/index.md
@@ -25,7 +25,7 @@ The source code for the examples are located in package **org.quartz.examples**.
 <th> Description </th>
 </tr>
 </thead>
-
+<tbody>
 <tr>
 <td width="75"> <a href="/documentation/quartz-1.x/examples/Example1" title="Example1">Example 1</a> </td>
 <td> First Quartz Program </td>

--- a/documentation/quartz-1.8.6/tutorials/TutorialLesson01.md
+++ b/documentation/quartz-1.8.6/tutorials/TutorialLesson01.md
@@ -1,4 +1,4 @@
-<div class="secNavPanel"><a href="./">Contents</a> | <a href="/documentation/quartz-1.x/tutorials/TutorialLesson02">Next&nbsp;&rsaquo;</a></div>
+<div class="secNavPanel"><a href="./">Contents</a> | <a href="/documentation/quartz-1.8.6/tutorials/TutorialLesson02">Next&nbsp;&rsaquo;</a></div>
 # Quartz Enterprise Job Scheduler 1.x Tutorial
 
 ## Lesson 1: Using Quartz
@@ -33,7 +33,7 @@ SchedulerFactory schedFact = new org.quartz.impl.StdSchedulerFactory();
 </pre>
 
 
-As you can see, working with quartz is rather simple. In <a href="/documentation/quartz-1.x/tutorials/TutorialLesson02"
+As you can see, working with quartz is rather simple. In <a href="/documentation/quartz-1.8.6/tutorials/TutorialLesson02"
     title="Tutorial Lesson 2">Lesson 2</a> we'll give a quick overview of Jobs and Triggers, so that you can more fully
 understand this example.
 

--- a/documentation/quartz-1.8.6/tutorials/TutorialLesson02.md
+++ b/documentation/quartz-1.8.6/tutorials/TutorialLesson02.md
@@ -1,4 +1,4 @@
-<div class="secNavPanel"><a href="./">Contents</a> | <a href="/documentation/quartz-1.x/tutorials/TutorialLesson01">&lsaquo;&nbsp;Prev</a> | <a href="/documentation/quartz-1.x/tutorials/TutorialLesson03">Next&nbsp;&rsaquo;</a></div>
+<div class="secNavPanel"><a href="./">Contents</a> | <a href="/documentation/quartz-1.8.6/tutorials/TutorialLesson01">&lsaquo;&nbsp;Prev</a> | <a href="/documentation/quartz-1.8.6/tutorials/TutorialLesson03">Next&nbsp;&rsaquo;</a></div>
 # Quartz Enterprise Job Scheduler 1.x Tutorial
 
 ## Lesson 2: Jobs and Triggers
@@ -59,8 +59,8 @@ job or trigger is its name + group. If you leave the group of the Job or Trigger
 having specified *Scheduler.DEFAULT_GROUP*.
 
 You now have a general idea about what Jobs and Triggers are, you can learn more about them in <a
-    href="/documentation/quartz-1.x/tutorials/TutorialLesson03" title="Tutorial Lesson 3">Lesson 3: More About Jobs &amp; JobDetails</a> and <a
-    href="/documentation/quartz-1.x/tutorials/TutorialLesson04" title="Tutorial Lesson 4">Lesson 4: More About Triggers</a>.
+    href="/documentation/quartz-1.8.6/tutorials/TutorialLesson03" title="Tutorial Lesson 3">Lesson 3: More About Jobs &amp; JobDetails</a> and <a
+    href="/documentation/quartz-1.8.6/tutorials/TutorialLesson04" title="Tutorial Lesson 4">Lesson 4: More About Triggers</a>.
 
 
 

--- a/documentation/quartz-1.8.6/tutorials/TutorialLesson03.md
+++ b/documentation/quartz-1.8.6/tutorials/TutorialLesson03.md
@@ -1,4 +1,4 @@
-<div class="secNavPanel"><a href="./">Contents</a> | <a href="/documentation/quartz-1.x/tutorials/TutorialLesson02">&lsaquo;&nbsp;Prev</a> | <a href="/documentation/quartz-1.x/tutorials/TutorialLesson04">Next&nbsp;&rsaquo;</a></div>
+<div class="secNavPanel"><a href="./">Contents</a> | <a href="/documentation/quartz-1.8.6/tutorials/TutorialLesson02">&lsaquo;&nbsp;Prev</a> | <a href="/documentation/quartz-1.8.6/tutorials/TutorialLesson04">Next&nbsp;&rsaquo;</a></div>
 # Quartz Enterprise Job Scheduler 1.x Tutorial
 
 

--- a/documentation/quartz-1.8.6/tutorials/TutorialLesson04.md
+++ b/documentation/quartz-1.8.6/tutorials/TutorialLesson04.md
@@ -1,4 +1,4 @@
-<div class="secNavPanel"><a href="./">Contents</a> | <a href="/documentation/quartz-1.x/tutorials/TutorialLesson03">&lsaquo;&nbsp;Prev</a> | <a href="/documentation/quartz-1.x/tutorials/TutorialLesson05">Next&nbsp;&rsaquo;</a></div>
+<div class="secNavPanel"><a href="./">Contents</a> | <a href="/documentation/quartz-1.8.6/tutorials/TutorialLesson03">&lsaquo;&nbsp;Prev</a> | <a href="/documentation/quartz-1.8.6/tutorials/TutorialLesson05">Next&nbsp;&rsaquo;</a></div>
 # Quartz Enterprise Job Scheduler 1.x Tutorial
 
 ## Lesson 4: More About Triggers
@@ -7,8 +7,8 @@ Like jobs, triggers are relatively easy to work with, but do contain a variety o
 need to be aware of and understand before you can make full use of Quartz. Also, as noted earlier, there are different
 types of triggers, that you can select to meet different scheduling needs.
 
-You will learn about the two most common types of triggers in <a href="/documentation/quartz-1.x/tutorials/TutorialLesson05"
-    title="Tutorial Lesson 5">Lesson 5: Simple Triggers</a> and <a href="/documentation/quartz-1.x/tutorials/TutorialLesson06"
+You will learn about the two most common types of triggers in <a href="/documentation/quartz-1.8.6/tutorials/TutorialLesson05"
+    title="Tutorial Lesson 5">Lesson 5: Simple Triggers</a> and <a href="/documentation/quartz-1.8.6/tutorials/TutorialLesson06"
     title="Tutorial Lesson 6">Lesson 6: Cron Triggers</a>.
 
 ### Calendars {#TutorialLesson4-Calendars}

--- a/documentation/quartz-1.8.6/tutorials/TutorialLesson05.md
+++ b/documentation/quartz-1.8.6/tutorials/TutorialLesson05.md
@@ -1,4 +1,4 @@
-<div class="secNavPanel"><a href="./">Contents</a> | <a href="/documentation/quartz-1.x/tutorials/TutorialLesson04">&lsaquo;&nbsp;Prev</a> | <a href="/documentation/quartz-1.x/tutorials/TutorialLesson06">Next&nbsp;&rsaquo;</a></div>
+<div class="secNavPanel"><a href="./">Contents</a> | <a href="/documentation/quartz-1.8.6/tutorials/TutorialLesson04">&lsaquo;&nbsp;Prev</a> | <a href="/documentation/quartz-1.8.6/tutorials/TutorialLesson06">Next&nbsp;&rsaquo;</a></div>
 # Quartz Enterprise Job Scheduler 1.x Tutorial
 
 ## Lesson 5: SimpleTrigger

--- a/documentation/quartz-1.8.6/tutorials/TutorialLesson06.md
+++ b/documentation/quartz-1.8.6/tutorials/TutorialLesson06.md
@@ -1,4 +1,4 @@
-<div class="secNavPanel"><a href="./">Contents</a> | <a href="/documentation/quartz-1.x/tutorials/TutorialLesson05">&lsaquo;&nbsp;Prev</a> | <a href="/documentation/quartz-1.x/tutorials/TutorialLesson07">Next&nbsp;&rsaquo;</a></div>
+<div class="secNavPanel"><a href="./">Contents</a> | <a href="/documentation/quartz-1.8.6/tutorials/TutorialLesson05">&lsaquo;&nbsp;Prev</a> | <a href="/documentation/quartz-1.8.6/tutorials/TutorialLesson07">Next&nbsp;&rsaquo;</a></div>
 # Quartz Enterprise Job Scheduler 1.x Tutorial
 
 ## Lesson 6: CronTrigger

--- a/documentation/quartz-1.8.6/tutorials/TutorialLesson07.md
+++ b/documentation/quartz-1.8.6/tutorials/TutorialLesson07.md
@@ -1,4 +1,4 @@
-<div class="secNavPanel"><a href="./">Contents</a> | <a href="/documentation/quartz-1.x/tutorials/TutorialLesson06">&lsaquo;&nbsp;Prev</a> | <a href="/documentation/quartz-1.x/tutorials/TutorialLesson08">Next&nbsp;&rsaquo;</a></div>
+<div class="secNavPanel"><a href="./">Contents</a> | <a href="/documentation/quartz-1.8.6/tutorials/TutorialLesson06">&lsaquo;&nbsp;Prev</a> | <a href="/documentation/quartz-1.8.6/tutorials/TutorialLesson08">Next&nbsp;&rsaquo;</a></div>
 # Quartz Enterprise Job Scheduler 1.x Tutorial
 
 ## Lesson 7: TriggerListeners and JobListeners

--- a/documentation/quartz-1.8.6/tutorials/TutorialLesson08.md
+++ b/documentation/quartz-1.8.6/tutorials/TutorialLesson08.md
@@ -1,4 +1,4 @@
-<div class="secNavPanel"><a href="./">Contents</a> | <a href="/documentation/quartz-1.x/tutorials/TutorialLesson07">&lsaquo;&nbsp;Prev</a> | <a href="/documentation/quartz-1.x/tutorials/TutorialLesson09">Next&nbsp;&rsaquo;</a></div>
+<div class="secNavPanel"><a href="./">Contents</a> | <a href="/documentation/quartz-1.8.6/tutorials/TutorialLesson07">&lsaquo;&nbsp;Prev</a> | <a href="/documentation/quartz-1.8.6/tutorials/TutorialLesson09">Next&nbsp;&rsaquo;</a></div>
 # Quartz Enterprise Job Scheduler 1.x Tutorial
 
 ## Lesson 8: SchedulerListeners

--- a/documentation/quartz-1.8.6/tutorials/TutorialLesson09.md
+++ b/documentation/quartz-1.8.6/tutorials/TutorialLesson09.md
@@ -1,4 +1,4 @@
-<div class="secNavPanel"><a href="./">Contents</a> | <a href="/documentation/quartz-1.x/tutorials/TutorialLesson08">&lsaquo;&nbsp;Prev</a> | <a href="/documentation/quartz-1.x/tutorials/TutorialLesson10">Next&nbsp;&rsaquo;</a></div>
+<div class="secNavPanel"><a href="./">Contents</a> | <a href="/documentation/quartz-1.8.6/tutorials/TutorialLesson08">&lsaquo;&nbsp;Prev</a> | <a href="/documentation/quartz-1.8.6/tutorials/TutorialLesson10">Next&nbsp;&rsaquo;</a></div>
 # Quartz Enterprise Job Scheduler 1.x Tutorial
 
 ## Lesson 9: Job Stores

--- a/documentation/quartz-1.8.6/tutorials/TutorialLesson10.md
+++ b/documentation/quartz-1.8.6/tutorials/TutorialLesson10.md
@@ -1,4 +1,4 @@
-<div class="secNavPanel"><a href="./">Contents</a> | <a href="/documentation/quartz-1.x/tutorials/TutorialLesson09">&lsaquo;&nbsp;Prev</a> | <a href="/documentation/quartz-1.x/tutorials/TutorialLesson11">Next&nbsp;&rsaquo;</a></div>
+<div class="secNavPanel"><a href="./">Contents</a> | <a href="/documentation/quartz-1.8.6/tutorials/TutorialLesson09">&lsaquo;&nbsp;Prev</a> | <a href="/documentation/quartz-1.8.6/tutorials/TutorialLesson11">Next&nbsp;&rsaquo;</a></div>
 # Quartz Enterprise Job Scheduler 1.x Tutorial
 
 ## Lesson 10: Configuration, Resource Usage and SchedulerFactory
@@ -32,7 +32,7 @@ org.quartz.simpl.SimpleThreadPool. This ThreadPool simply maintains a fixed set 
 never shrinks. But it is otherwise quite robust and is very well tested - as nearly everyone using Quartz uses this
 pool.
 
-***JobStores*** and ***DataSources*** were discussed in <a href="/documentation/quartz-1.x/tutorials/TutorialLesson09"
+***JobStores*** and ***DataSources*** were discussed in <a href="/documentation/quartz-1.8.6/tutorials/TutorialLesson09"
     title="Tutorial Lesson 9">Lesson 9</a> of this tutorial. Worth noting here, is the fact that all JobStores implement
 the org.quartz.spi.JobStore interface - and that if one of the bundled JobStores does not fit your needs, then you can
 make your own.

--- a/documentation/quartz-1.8.6/tutorials/TutorialLesson11.md
+++ b/documentation/quartz-1.8.6/tutorials/TutorialLesson11.md
@@ -1,4 +1,4 @@
-<div class="secNavPanel"><a href="./">Contents</a> | <a href="/documentation/quartz-1.x/tutorials/TutorialLesson10">&lsaquo;&nbsp;Prev</a> | <a href="/documentation/quartz-1.x/tutorials/TutorialLesson12">Next&nbsp;&rsaquo;</a></div>
+<div class="secNavPanel"><a href="./">Contents</a> | <a href="/documentation/quartz-1.8.6/tutorials/TutorialLesson10">&lsaquo;&nbsp;Prev</a> | <a href="/documentation/quartz-1.8.6/tutorials/TutorialLesson12">Next&nbsp;&rsaquo;</a></div>
 # Quartz Enterprise Job Scheduler 1.x Tutorial
 
 ## Lesson 11: Advanced (Enterprise) Features
@@ -36,7 +36,7 @@ same node that just was just active for non-busy (e.g. one or two triggers) sche
 **Clustering With TerracottaJobStore**
 
 Simply configure the scheduler to use TerracottaJobStore (covered in 
-<a href="/documentation/quartz-1.x/tutorials/TutorialLesson09" title="Tutorial Lesson 9">Lesson 9: JobStores</a>), and your scheduler will be all
+<a href="/documentation/quartz-1.8.6/tutorials/TutorialLesson09" title="Tutorial Lesson 9">Lesson 9: JobStores</a>), and your scheduler will be all
 set for clustering.
 
 You may also want to consider implications of how you setup your Terracotta server, particularly configuration 
@@ -49,7 +49,7 @@ More information about this JobStore and Terracotta can be found at
 
 ### JTA Transactions {#TutorialLesson11-JTATransactions}
 
-As explained in <a href="/documentation/quartz-1.x/tutorials/TutorialLesson09" title="Tutorial Lesson 9">Lesson 9: JobStores</a>, JobStoreCMT
+As explained in <a href="/documentation/quartz-1.8.6/tutorials/TutorialLesson09" title="Tutorial Lesson 9">Lesson 9: JobStores</a>, JobStoreCMT
 allows Quartz scheduling operations to be performed within larger JTA transactions.
 
 Jobs can also execute within a JTA transaction (UserTransaction) by setting the

--- a/documentation/quartz-1.8.6/tutorials/TutorialLesson12.md
+++ b/documentation/quartz-1.8.6/tutorials/TutorialLesson12.md
@@ -1,4 +1,4 @@
-<div class="secNavPanel"><a href="./">Contents</a> | <a href="/documentation/quartz-1.x/tutorials/TutorialLesson11">&lsaquo;&nbsp;Prev</a> | <a href="crontrigger">Next&nbsp;&rsaquo;</a></div>
+<div class="secNavPanel"><a href="./">Contents</a> | <a href="/documentation/quartz-1.8.6/tutorials/TutorialLesson11">&lsaquo;&nbsp;Prev</a> | <a href="crontrigger">Next&nbsp;&rsaquo;</a></div>
 # Quartz Enterprise Job Scheduler 1.x Tutorial
 
 ## Lesson 12: Miscellaneous Features of Quartz

--- a/documentation/quartz-1.8.6/tutorials/crontrigger.md
+++ b/documentation/quartz-1.8.6/tutorials/crontrigger.md
@@ -1,4 +1,4 @@
-<div class="secNavPanel"><a href="./">Contents</a> | <a href="/documentation/quartz-1.x/tutorials/TutorialLesson12">&lsaquo;&nbsp;Prev</a> </div>
+<div class="secNavPanel"><a href="./">Contents</a> | <a href="/documentation/quartz-1.8.6/tutorials/TutorialLesson12">&lsaquo;&nbsp;Prev</a> </div>
 # CronTrigger Tutorial
 
 ## Introduction {#CronTriggersTutorial-Introduction}

--- a/documentation/quartz-1.8.6/tutorials/index.md
+++ b/documentation/quartz-1.8.6/tutorials/index.md
@@ -3,15 +3,15 @@
 
 ## Choose a Lesson:
 
-+ <a href="/documentation/quartz-1.x/tutorials/TutorialLesson01" title="Tutorial Lesson1">Lesson 1: Using Quartz</a>
-+ <a href="/documentation/quartz-1.x/tutorials/TutorialLesson02" title="Tutorial Lesson2">Lesson 2: Jobs And Triggers</a>
-+ <a href="/documentation/quartz-1.x/tutorials/TutorialLesson03" title="Tutorial Lesson3">Lesson 3: More About Jobs &amp; JobDetails</a>
-+ <a href="/documentation/quartz-1.x/tutorials/TutorialLesson04" title="Tutorial Lesson4">Lesson 4: More About Triggers</a>
-+ <a href="/documentation/quartz-1.x/tutorials/TutorialLesson05" title="Tutorial Lesson5">Lesson 5: SimpleTriggers</a>
-+ <a href="/documentation/quartz-1.x/tutorials/TutorialLesson06" title="Tutorial Lesson6">Lesson 6: CronTriggers</a>
-+ <a href="/documentation/quartz-1.x/tutorials/TutorialLesson07" title="Tutorial Lesson7">Lesson 7: TriggerListeners &amp; JobListeners</a>
-+ <a href="/documentation/quartz-1.x/tutorials/TutorialLesson08" title="Tutorial Lesson8">Lesson 8: SchedulerListeners</a>
-+ <a href="/documentation/quartz-1.x/tutorials/TutorialLesson09" title="Tutorial Lesson9">Lesson 9: JobStores</a>
-+ <a href="/documentation/quartz-1.x/tutorials/TutorialLesson10" title="Tutorial Lesson10">Lesson 10: Configuration, Resource Usage and SchedulerFactory</a>
-+ <a href="/documentation/quartz-1.x/tutorials/TutorialLesson11" title="Tutorial Lesson11">Lesson 11: Advanced (Enterprise) Features</a>
-+ <a href="/documentation/quartz-1.x/tutorials/TutorialLesson12" title="Tutorial Lesson12">Lesson 12: Miscellaneous Features</a>
++ <a href="/documentation/quartz-1.8.6/tutorials/TutorialLesson01" title="Tutorial Lesson1">Lesson 1: Using Quartz</a>
++ <a href="/documentation/quartz-1.8.6/tutorials/TutorialLesson02" title="Tutorial Lesson2">Lesson 2: Jobs And Triggers</a>
++ <a href="/documentation/quartz-1.8.6/tutorials/TutorialLesson03" title="Tutorial Lesson3">Lesson 3: More About Jobs &amp; JobDetails</a>
++ <a href="/documentation/quartz-1.8.6/tutorials/TutorialLesson04" title="Tutorial Lesson4">Lesson 4: More About Triggers</a>
++ <a href="/documentation/quartz-1.8.6/tutorials/TutorialLesson05" title="Tutorial Lesson5">Lesson 5: SimpleTriggers</a>
++ <a href="/documentation/quartz-1.8.6/tutorials/TutorialLesson06" title="Tutorial Lesson6">Lesson 6: CronTriggers</a>
++ <a href="/documentation/quartz-1.8.6/tutorials/TutorialLesson07" title="Tutorial Lesson7">Lesson 7: TriggerListeners &amp; JobListeners</a>
++ <a href="/documentation/quartz-1.8.6/tutorials/TutorialLesson08" title="Tutorial Lesson8">Lesson 8: SchedulerListeners</a>
++ <a href="/documentation/quartz-1.8.6/tutorials/TutorialLesson09" title="Tutorial Lesson9">Lesson 9: JobStores</a>
++ <a href="/documentation/quartz-1.8.6/tutorials/TutorialLesson10" title="Tutorial Lesson10">Lesson 10: Configuration, Resource Usage and SchedulerFactory</a>
++ <a href="/documentation/quartz-1.8.6/tutorials/TutorialLesson11" title="Tutorial Lesson11">Lesson 11: Advanced (Enterprise) Features</a>
++ <a href="/documentation/quartz-1.8.6/tutorials/TutorialLesson12" title="Tutorial Lesson12">Lesson 12: Miscellaneous Features</a>


### PR DESCRIPTION
When quartz-1.x directory was renamed to quartz-1.8.5 (later removed and replaced by quartz-1.8.6), the old quartz-1.x name continued to be used in internal links between documentation pages.

This PR aims to fix these broken links.

This PR should also resolve a couple minor Markdown syntax issues:
* Commented out list items still rendered in HTML output: http://www.quartz-scheduler.org/documentation/quartz-1.8.6/cookbook/
* Stray `</tbody>`: http://www.quartz-scheduler.org/documentation/quartz-1.8.6/examples/
