### PR TITLE
quartz docs 2.3.0 has a spelling mistake in live site. In line 68 I found tather ?

### DIFF
--- a/documentation/quartz-2.3.0/tutorials/tutorial-lesson-07.md
+++ b/documentation/quartz-2.3.0/tutorials/tutorial-lesson-07.md
@@ -65,7 +65,7 @@ To create a listener, simply create an object that implements the org.quartz.Tri
 org.quartz.JobListener interface. Listeners are then registered with the scheduler during run time, and must be given a
 name (or rather, they must advertise their own name via their getName() method).
 
-For your convenience, tather than implementing those interfaces, your class could also extend the class
+For your convenience, rather than implementing those interfaces, your class could also extend the class
 JobListenerSupport or TriggerListenerSupport and simply override the events you're interested in.
 
 Listeners are registered with the scheduler's ListenerManager along with a Matcher that describes which Jobs/Triggers


### PR DESCRIPTION
line 68 tather -> rather
![quartz_docs_2 3 0_](https://user-images.githubusercontent.com/80060492/221502730-a6542bd3-5c4b-4dcd-847d-c8e15cc5c576.png)
